### PR TITLE
Fix outputs, dead letter target and logical id alphanumeric error

### DIFF
--- a/sqs.cfndsl.rb
+++ b/sqs.cfndsl.rb
@@ -7,40 +7,41 @@ CloudFormation do
   extra_tags.each { |key,value| tags << { Key: key, Value: value } } if defined? extra_tags
 
   queues.each do |queue|
-    SQS_Queue(queue['name']) do
-      QueueName FnJoin("-", [Ref('EnvironmentName'), queue['name']]) unless (queue.has_key?('generated_name')) && (queue['generated_name'])
-      VisibilityTimeout queue['visibility_timeout'] if queue.has_key?('visibility_timeout')
-      DelaySeconds queue['delay_seconds'] if queue.has_key?('delay_seconds')
-      MaximumMessageSize queue['maximum_message_size'] if queue.has_key?('maximum_message_size')
-      MessageRetentionPeriod queue['message_retention_period'] if queue.has_key?('message_retention_period')
-      ReceiveMessageWaitTimeSeconds queue['receive_message_wait_time_seconds'] if queue.has_key?('receive_message_wait_time_seconds')
+      logical_id = queue['name'].gsub(/[^0-9a-z ]/i, '')
+      SQS_Queue(logical_id) do
+          QueueName FnJoin("-", [Ref('EnvironmentName'), queue['name']]) unless (queue.has_key?('generated_name')) && (queue['generated_name'])
+          VisibilityTimeout queue['visibility_timeout'] if queue.has_key?('visibility_timeout')
+          DelaySeconds queue['delay_seconds'] if queue.has_key?('delay_seconds')
+          MaximumMessageSize queue['maximum_message_size'] if queue.has_key?('maximum_message_size')
+          MessageRetentionPeriod queue['message_retention_period'] if queue.has_key?('message_retention_period')
+          ReceiveMessageWaitTimeSeconds queue['receive_message_wait_time_seconds'] if queue.has_key?('receive_message_wait_time_seconds')
 
-      if queue.has_key?('redrive_policy')
-        RedrivePolicy ({
-          deadLetterTargetArn: Ref(queue['redrive_policy']['queue']),
-          maxReceiveCount: queue['redrive_policy']['count']
-        })
+          if queue.has_key?('redrive_policy')
+          RedrivePolicy ({
+              deadLetterTargetArn: FnGetAtt(queue['redrive_policy']['queue'].gsub(/[^0-9a-z ]/i, ''), 'Arn'),
+              maxReceiveCount: queue['redrive_policy']['count']
+          })
+          end
+
+          if (queue.has_key?('fifo_queue')) && (queue['fifo_queue'])
+          FifoQueue true
+          ContentBasedDeduplication queue['content_based_deduplication'] if queue.has_key?('content_based_deduplication')
+          end
+
+          Property('Tags', tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), queue['name'] ]) }])
       end
 
-      if (queue.has_key?('fifo_queue')) && (queue['fifo_queue'])
-        FifoQueue true
-        ContentBasedDeduplication queue['content_based_deduplication'] if queue.has_key?('content_based_deduplication')
-      end
+      Output("#{logical_id}QueueUrl") {
+          Value(Ref(logical_id))
+          Export FnSub("${EnvironmentName}-#{component_name}-#{logical_id}Url")
+      }
 
-      Property('Tags', tags + [{ Key: 'Name', Value: FnJoin('-', [ Ref(:EnvironmentName), queue['name'] ]) }])
+      Output("#{logical_id}QueueName") {
+          Value(FnGetAtt(logical_id, 'QueueName'))
+          Export FnSub("${EnvironmentName}-#{component_name}-#{logical_id}Name")
+      }
 
-    end
-
-    Output("QueueUrl") {
-      Value(Ref(queue['name']))
-      Export FnSub("${EnvironmentName}-#{component_name}-#{queue['name']}Url")
-    }
-
-    Output("QueueName") {
-      Value(FnGetAtt(queue['name'], 'QueueName'))
-      Export FnSub("${EnvironmentName}-#{component_name}-#{queue['name']}Name")
-    }
-    Output('QueueArn', FnGetAtt(queue['name'], 'Arn'))
+      Output("#{logical_id}QueueArn", FnGetAtt(logical_id, 'Arn'))
 
   end if (defined? queues) && (!queues.nil?)
 

--- a/sqs.cfndsl.rb
+++ b/sqs.cfndsl.rb
@@ -5,9 +5,9 @@ CloudFormation do
   tags << { Key: 'EnvironmentType', Value: Ref(:EnvironmentType) }
 
   extra_tags.each { |key,value| tags << { Key: key, Value: value } } if defined? extra_tags
-
+  filter = /[^0-9a-z ]/i
   queues.each do |queue|
-      logical_id = queue['name'].gsub(/[^0-9a-z ]/i, '')
+      logical_id = queue['name'].gsub(filter, '')
       SQS_Queue(logical_id) do
           QueueName FnJoin("-", [Ref('EnvironmentName'), queue['name']]) unless (queue.has_key?('generated_name')) && (queue['generated_name'])
           VisibilityTimeout queue['visibility_timeout'] if queue.has_key?('visibility_timeout')
@@ -18,7 +18,7 @@ CloudFormation do
 
           if queue.has_key?('redrive_policy')
           RedrivePolicy ({
-              deadLetterTargetArn: FnGetAtt(queue['redrive_policy']['queue'].gsub(/[^0-9a-z ]/i, ''), 'Arn'),
+              deadLetterTargetArn: FnGetAtt(queue['redrive_policy']['queue'].gsub(filter, ''), 'Arn'),
               maxReceiveCount: queue['redrive_policy']['count']
           })
           end


### PR DESCRIPTION
Cloudformation does not accept logical ids with characters other than alphanumeric. When using a queue name with '-' in it, the queue name is fine but the logical id is not. Dead letter target arn was using a ref which brings back the queue url not the arn. Exports were over-riding each other as the logical id was not unique.